### PR TITLE
Adds Writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ mbox
 [![Coverage Status](https://coveralls.io/repos/blabber/mbox/badge.svg)](https://coveralls.io/r/blabber/mbox)
 [![GoDoc](https://godoc.org/github.com/blabber/mbox?status.svg)](https://godoc.org/github.com/blabber/mbox)
 
-Package mbox parses the mbox file format into messages.
+Package mbox parses the mbox file format into messages and formats messages into mbox files.
 
 Documentation
 -------------

--- a/mbox.go
+++ b/mbox.go
@@ -1,0 +1,5 @@
+// Package mbox parses and formats the mbox file format.
+//
+// As the mbox file format is not standardized this package expects the least
+// common denominator, the so called mboxo format.
+package mbox

--- a/scanner.go
+++ b/scanner.go
@@ -61,7 +61,7 @@ func scanMessage(data []byte, atEOF bool) (advance int, token []byte, err error)
 	return e + 1, data[n+1 : e], nil
 }
 
-// Mbox provides an interface to read a sequence of messages from an mbox.
+// Reader provides an interface to read a sequence of messages from an mbox.
 // Calling the Next method steps through the messages. The current message can
 // then be accessed by calling the Message method.
 //
@@ -73,26 +73,26 @@ func scanMessage(data []byte, atEOF bool) (advance int, token []byte, err error)
 // error occured while calling Next or if you have skipped past the last message
 // using Next. If Next returned true, you can expect Message to return a valid
 // *mail.Message.
-type Mbox struct {
+type Scanner struct {
 	s   *bufio.Scanner
 	m   *mail.Message
 	err error
 }
 
-// New returns a new *Mbox to read messages from mbox file format data provided
+// New returns a new *Scanner to read messages from mbox file format data provided
 // by io.Reader r.
-func New(r io.Reader) *Mbox {
+func NewScanner(r io.Reader) *Scanner {
 	s := bufio.NewScanner(r)
 	s.Split(scanMessage)
 
-	return &Mbox{s, nil, nil}
+	return &Scanner{s, nil, nil}
 }
 
 // Next skips to the next message and returns true. It will return false if
 // there are no messages left or an error occurs. You can call the Err method to
 // check if an error occured. If Next returns false and Err returns nil there
 // are no messages left.
-func (m *Mbox) Next() bool {
+func (m *Scanner) Next() bool {
 	m.m = nil
 	if m.err != nil {
 		return false
@@ -112,7 +112,7 @@ func (m *Mbox) Next() bool {
 }
 
 // Err returns the first error that occured while calling Next.
-func (m *Mbox) Err() error {
+func (m *Scanner) Err() error {
 	return m.err
 }
 
@@ -121,7 +121,7 @@ func (m *Mbox) Err() error {
 //
 // If Next returned true, you can expect Message to return a valid
 // *mail.Message.
-func (m *Mbox) Message() *mail.Message {
+func (m *Scanner) Message() *mail.Message {
 	if m.err != nil {
 		return nil
 	}

--- a/scanner.go
+++ b/scanner.go
@@ -4,10 +4,6 @@
 // think this stuff is worth it, you can buy me a beer in return.
 //                                                             Tobias Rehbein
 
-// Package mbox parses the mbox file format into messages.
-//
-// As the mbox file format is not standardized this package expects the least
-// common denominator, the so called mboxo format.
 package mbox
 
 import (
@@ -61,7 +57,7 @@ func scanMessage(data []byte, atEOF bool) (advance int, token []byte, err error)
 	return e + 1, data[n+1 : e], nil
 }
 
-// Reader provides an interface to read a sequence of messages from an mbox.
+// Scanner provides an interface to read a sequence of messages from an mbox.
 // Calling the Next method steps through the messages. The current message can
 // then be accessed by calling the Message method.
 //

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -300,7 +300,7 @@ func TestScanMessageMboxWithOneMessageWithoutNewlineAtEOF(t *testing.T) {
 
 func testMboxMessage(t *testing.T, mbox string, count int) {
 	b := bytes.NewBufferString(mbox)
-	m := New(b)
+	m := NewScanner(b)
 
 	for i := 0; i < count; i++ {
 		if !m.Next() {
@@ -358,7 +358,7 @@ func TestMboxMessageWithThreeMessagesMalformedButValid(t *testing.T) {
 
 func testMboxMessageInvalid(t *testing.T, mbox string) {
 	b := bytes.NewBufferString(mbox)
-	m := New(b)
+	m := NewScanner(b)
 
 	if m.Next() {
 		t.Errorf("Next() succeeded")
@@ -405,7 +405,7 @@ This is another simple test.
 Bye.
 `)
 
-	mbox := New(r)
+	mbox := NewScanner(r)
 	for mbox.Next() {
 		// If Next() returns true, you can expect Message() to return a
 		// valid *mail.Message.

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -385,7 +385,7 @@ func TestMboxMessageWithOneMessageMissingHeaders(t *testing.T) {
 	testMboxMessageInvalid(t, mboxWithOneMessageMissingHeaders)
 }
 
-func ExampleMbox() {
+func ExampleScanner() {
 	r := strings.NewReader(`From herp.derp at example.com  Thu Jan  1 00:00:01 2015
 From: herp.derp at example.com (Herp Derp)
 Date: Thu, 01 Jan 2015 00:00:01 +0100

--- a/writer.go
+++ b/writer.go
@@ -8,8 +8,10 @@ package mbox
 
 import (
 	"io"
+	"io/ioutil"
 	"net/mail"
 	"net/textproto"
+	"strings"
 	"time"
 )
 
@@ -68,8 +70,16 @@ func (w *Writer) Write(m *mail.Message) (N int, err error) {
 		return
 	}
 
-	nn, err := io.Copy(w.w, m.Body)
-	N += int(nn)
+	// Escape lines begining with "From "
+	// TODO: use golang.org/x/text/transform
+	b, err := ioutil.ReadAll(m.Body)
+	if err != nil {
+		return
+	}
+
+	r := strings.NewReplacer("\nFrom ", "\n>From ")
+	n, err = r.WriteString(w.w, string(b))
+	N += n
 	if err != nil {
 		return
 	}

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,80 @@
+// "THE BEER-WARE LICENSE" (Revision 42):
+// <contact@emersion.fr> wrote this file. As long as you retain this notice
+// you can do whatever you want with this stuff. If we meet some day, and you
+// think this stuff is worth it, you can buy me a beer in return.
+//                                                                 emersion
+
+package mbox
+
+import (
+	"io"
+	"net/mail"
+	"net/textproto"
+	"time"
+)
+
+// Write a MIME header.
+func writeMIMEHeader(w io.Writer, header textproto.MIMEHeader) (N int, err error) {
+	var n int
+
+	for name, values := range header {
+		for _, value := range values {
+			n, err = io.WriteString(w, name + ": " + value + "\r\n")
+			N += n
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	n, err = io.WriteString(w, "\r\n")
+	N += n
+	return
+}
+
+// Writer writes messages to a mbox stream.
+type Writer struct {
+	w io.Writer
+}
+
+// NewWriter creates a new *Writer that writes messages to w.
+func NewWriter(w io.Writer) *Writer {
+	return &Writer{w}
+}
+
+// Write writes a message to the mbox stream. It returns the number of bytes
+// written.
+func (w *Writer) Write(m *mail.Message) (N int, err error) {
+	from := "???@???"
+	if fromList, err := m.Header.AddressList("From"); err == nil && len(fromList) > 0 {
+		from = fromList[0].Address
+	}
+
+	date := ""
+	if t, err := m.Header.Date(); err == nil {
+		date = t.Format(time.ANSIC)
+	}
+
+	line := "From " + from + " " + date + "\n"
+	n, err := io.WriteString(w.w, line)
+	N += n
+	if err != nil {
+		return
+	}
+
+	n, err = writeMIMEHeader(w.w, textproto.MIMEHeader(m.Header))
+	N += n
+	if err != nil {
+		return
+	}
+
+	nn, err := io.Copy(w.w, m.Body)
+	N += int(nn)
+	if err != nil {
+		return
+	}
+
+	n, err = io.WriteString(w.w, "\n")
+	N += n
+	return
+}

--- a/writer.go
+++ b/writer.go
@@ -21,7 +21,7 @@ func writeMIMEHeader(w io.Writer, header textproto.MIMEHeader) (N int, err error
 
 	for name, values := range header {
 		for _, value := range values {
-			n, err = io.WriteString(w, name + ": " + value + "\r\n")
+			n, err = io.WriteString(w, name + ": " + value + "\n")
 			N += n
 			if err != nil {
 				return
@@ -29,7 +29,7 @@ func writeMIMEHeader(w io.Writer, header textproto.MIMEHeader) (N int, err error
 		}
 	}
 
-	n, err = io.WriteString(w, "\r\n")
+	n, err = io.WriteString(w, "\n")
 	N += n
 	return
 }
@@ -44,9 +44,9 @@ func NewWriter(w io.Writer) *Writer {
 	return &Writer{w}
 }
 
-// Write writes a message to the mbox stream. It returns the number of bytes
-// written.
-func (w *Writer) Write(m *mail.Message) (N int, err error) {
+// WriteMessage writes a message to the mbox stream. It returns the number of
+// bytes written.
+func (w *Writer) WriteMessage(m *mail.Message) (N int, err error) {
 	from := "???@???"
 	if fromList, err := m.Header.AddressList("From"); err == nil && len(fromList) > 0 {
 		from = fromList[0].Address

--- a/writer.go
+++ b/writer.go
@@ -84,7 +84,7 @@ func (w *Writer) WriteMessage(m *mail.Message) (N int, err error) {
 		return
 	}
 
-	n, err = io.WriteString(w.w, "\n")
+	n, err = io.WriteString(w.w, "\n\n")
 	N += n
 	return
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -56,6 +56,7 @@ And, by the way, this is how a "From" line is escaped in mboxo format:
 >From Herp Derp with love.
 
 Bye.
+
 From ???@??? Fri Jan  2 00:00:01 2015
 Date: Thu, 02 Jan 2015 00:00:01 +0100
 
@@ -64,6 +65,7 @@ This is another simple test.
 Another line.
 
 Bye.
+
 `
 
 	s := testWriter(t, messages)

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,0 +1,73 @@
+package mbox
+
+import (
+	"bytes"
+	"net/mail"
+	"strings"
+	"testing"
+)
+
+func testWriter(t *testing.T, messages []*mail.Message) string {
+	b := &bytes.Buffer{}
+	w := NewWriter(b)
+
+	for _, m := range messages {
+		if _, err := w.WriteMessage(m); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return b.String()
+}
+
+func TestWriter(t *testing.T) {
+	messages := []*mail.Message{
+		&mail.Message{
+			Header: map[string][]string{
+				"Date": {"Thu, 01 Jan 2015 00:00:01 +0100"},
+			},
+			Body: strings.NewReader(`This is a simple test.
+
+And, by the way, this is how a "From" line is escaped in mboxo format:
+
+From Herp Derp with love.
+
+Bye.`),
+		},
+		&mail.Message{
+			Header: map[string][]string{
+				"Date": {"Thu, 02 Jan 2015 00:00:01 +0100"},
+			},
+			Body: strings.NewReader(`This is another simple test.
+
+Another line.
+
+Bye.`),
+		},
+	}
+
+	expected := `From ???@??? Thu Jan  1 00:00:01 2015
+Date: Thu, 01 Jan 2015 00:00:01 +0100
+
+This is a simple test.
+
+And, by the way, this is how a "From" line is escaped in mboxo format:
+
+>From Herp Derp with love.
+
+Bye.
+From ???@??? Fri Jan  2 00:00:01 2015
+Date: Thu, 02 Jan 2015 00:00:01 +0100
+
+This is another simple test.
+
+Another line.
+
+Bye.
+`
+
+	s := testWriter(t, messages)
+	if s != expected {
+		t.Error("Invalid mbox output:", s)
+	}
+}


### PR DESCRIPTION
Renames `Mbox` to `Scanner` and adds `Writer`.

This breaks compatibility with the previous version.

Edit: the test is failing because `$COVERALLS_TOKEN` is not defined.
