### PR TITLE
Adds Scanner.Buffer()

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -124,3 +124,12 @@ func (m *Scanner) Message() *mail.Message {
 
 	return m.m
 }
+
+
+// Buffer sets the initial buffer to use when scanning and the maximum size of
+// buffer that may be allocated during scanning.
+//
+// Buffer panics if it is called after scanning has started.
+func (m *Scanner) Buffer(buf []byte, max int) {
+	m.s.Buffer(buf, max)
+}


### PR DESCRIPTION
By default, `bufio.Scanner` has a buffer size limit, which is set to 10KiB (see https://golang.org/pkg/bufio/#Scanner.Buffer). Thus, `mbox.Scanner` cannot handle messages larger than that.

This PR adds a `Buffer()` function to be able to increase this limit.
