### PR TITLE
This should go in Issue4.

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -79,6 +79,8 @@ type Scanner struct {
 // provided by io.Reader r.
 func NewScanner(r io.Reader) *Scanner {
 	s := bufio.NewScanner(r)
+	buf := make([]byte, 0, 64*1024)
+	s.Buffer(buf, 1024*1024*100)
 	s.Split(scanMessage)
 
 	return &Scanner{s, nil, nil}
@@ -124,7 +126,6 @@ func (m *Scanner) Message() *mail.Message {
 
 	return m.m
 }
-
 
 // Buffer sets the initial buffer to use when scanning and the maximum size of
 // buffer that may be allocated during scanning.


### PR DESCRIPTION
Essentially make the buffer for the scanner longer, such that longer messages don't overrun the buffer and cause errors/failures.