### PR TITLE
Remove trailing semi-colon of bounday attribute if present

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -67,7 +67,11 @@ func scanMessage(data []byte, atEOF bool) (int, []byte, error) {
 		for _, v := range splt {
 			if strings.HasPrefix(v, "boundary=") {
 				c := strings.Index(v, "=") + 1
-				boundaryEnd = "--" + strings.Trim(v[c:], `"'`) + "--"
+				semi := strings.Index(v[c:], ";")
+				if semi == -1 {
+					semi = len(v[c:])
+				}
+				boundaryEnd = "--" + strings.Trim(v[c:c+semi], `"'`) + "--"
 				break
 			}
 		}


### PR DESCRIPTION
Please take a look.

Fixes #13.