### PR TITLE
Use bufio.Reader instead of bufio.Scanner to support messages with long lines

### DIFF
--- a/mbox.go
+++ b/mbox.go
@@ -4,4 +4,7 @@
 // common denominator, the so called mboxo format.
 package mbox
 
-var header = []byte("From ")
+var (
+	header        = []byte("From ")
+	escapedHeader = append([]byte{'>'}, header...)
+)


### PR DESCRIPTION
Message with very long lines (longer than `bufio.MaxScanTokenSize` which is `64 * 1024`) cannot be parsed using `bufio.Scanner`, see the [doc](https://golang.org/pkg/bufio/#Scanner):

> Programs that need more control over error handling or large tokens, or must run sequential scans on a reader, should use bufio.Reader instead.

To support also long lines, `bufio.Reader` should be used.