### PR TITLE
Use bufio.ReadBytes instead of bufio.ReadLine

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -91,16 +91,9 @@ func NewReader(r io.Reader) *Reader {
 func (r *Reader) NextMessage() (io.Reader, error) {
 	if r.mr == nil {
 		for {
-			b, isPrefix, err := r.r.ReadLine()
+			b, err := r.r.ReadBytes('\n')
 			if err != nil {
 				return nil, err
-			}
-			// Discard the rest of the line.
-			for isPrefix {
-				_, isPrefix, err = r.r.ReadLine()
-				if err != nil {
-					return nil, err
-				}
 			}
 			if len(b) == 0 {
 				continue

--- a/reader.go
+++ b/reader.go
@@ -95,7 +95,7 @@ func (r *Reader) NextMessage() (io.Reader, error) {
 			if err != nil {
 				return nil, err
 			}
-			if len(b) == 0 {
+			if len(b) <= 1 {
 				continue
 			}
 			if bytes.HasPrefix(b, header) {


### PR DESCRIPTION
Calling ReadLine invalidates whatever data you pull from it before unless you make a separate copy of it. If that codepath ever does trigger, you'd only be left with the very last chunk of the line.

One notable difference with this though, ReadLine eats and hides EOF errors while ReadBytes doesn't.