### PR TITLE
reader: don't miscount bytes written upon successive calls to Write

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -95,9 +95,9 @@ func (r *Reader) NextMessage() (io.Reader, error) {
 			if err != nil {
 				return nil, err
 			}
-			
+
 			isFromLine := bytes.HasPrefix(b, header)
-			
+
 			// Discard the rest of the line.
 			for isPrefix {
 				_, isPrefix, err = r.r.ReadLine()

--- a/writer_test.go
+++ b/writer_test.go
@@ -92,3 +92,23 @@ Bye.
 		t.Error("Invalid mbox output:", s)
 	}
 }
+
+// Test for the fix for https://github.com/emersion/go-mbox/issues/21
+func TestMultipleWrites(t *testing.T) {
+	var buffer bytes.Buffer
+	mboxWriter := NewWriter(&buffer)
+	w, err := mboxWriter.CreateMessage("-", time.Time{})
+	if err != nil {
+		panic(err)
+	}
+	b := []byte("some text   ")
+	n, err := w.Write(b)
+	if n != len(b) {
+		t.Errorf("unexpected return value for write: %d (expected %d)", n, len(b))
+	}
+	b = []byte("end of line\n")
+	n, err = w.Write(b)
+	if n != len(b) {
+		t.Errorf("unexpected return value for write: %d (expected %d)", n, len(b))
+	}
+}


### PR DESCRIPTION
As soon as one calls Write multiple times on the same Writer, Write will start to return an incorrect number of bytes: instead of returning the number of bytes added, it returns the number of bytes written through the lifetime of the Writer; this is https://github.com/emersion/go-mbox/issues/21.

This patch fixes this by remembering the number of bytes already in the buffer *before* writing, and taking it into account.

Note that we're still lying to the caller when we replace \r\n by \n, but it's not as easy to fix because Write(p) *needs* to return len(p). If it returns less (which would be the truth if we do this replacement), the IO layer will complain about a "short write". I'll probably have to address this in another PR, but let's decouple.